### PR TITLE
Avoiding saying "ERROR" when there was no problem.

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,8 +65,13 @@ class ExpireSnapshots {
           var snapsToDeleteParams  = ExpireSnapshots.delParams(filteredSnaps.toDelete, config.dryRun);
           async.mapSeries(snapsToDeleteParams, ExpireSnapshots.delOneSnap, volumeCallback);
         }, function (err, results) {
-          console.log("ERROR");
-          console.dir(err)
+          if (err) {
+            console.log("ERROR");
+            console.dir(err)
+          } else {
+            console.log("SUCCESS");
+          }
+
           console.log("RESULTS");
           console.dir(results)
           console.log("END snapshot expiration for region: "+region);


### PR DESCRIPTION
It's kinda creepy to see the logs say lines like the following when there's no problem to report.

    ERROR
    null