### PR TITLE
Removing duplicate aws-sdk, updating dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,15 +4,14 @@
   "description": "Expire EBS snapshots from AWS Lambda using Grandfather Father Son retention rules",
   "main": "index.js",
   "devDependencies": {
-    "aws-sdk": "^2.6.10",
     "chai": "^3.5.0",
     "mocha": "^3.1.2"
   },
   "dependencies": {
-    "async": "^2.1.4",
+    "async": "^2.5.0",
     "aws-sdk": "^2.6.10",
     "grandfatherson": "^1.1.1",
-    "lodash": "^4.17.2"
+    "lodash": "^4.17.4"
   },
   "scripts": {
     "test": "mocha --reporter=spec test/*.js",


### PR DESCRIPTION
The newer version of npm is reporting this as a warning. Removing `aws-sdk` from the `devDependencies` still leaves it as a regular dependency.